### PR TITLE
CLI Improvements for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ pip install opencv-python
 3. Run `python3 cameraCalib.py YOUR_PICTURES_DIRECTORY`
 4. Copy-paste the `intrinsic_parameters` and `distortion_parameters` into your rdk config.
 
+Note: On Linux with GTK you may have to run the script with the `--no-gui` flag. Ex: `python3 cameraCalib.py --no-gui YOUR_PICTURES_DIRECTORY`
+
 ### Example images
 ![alt text](ExampleImages.png "Example images")
 

--- a/cameraCalib.py
+++ b/cameraCalib.py
@@ -9,7 +9,7 @@ import glob
 import sys
 import random
 
-noGui = '--no-gui' in sys.argv
+showGui = not ('--no-gui' in sys.argv)
 imagesBasePath = sys.argv[-1]
 
 # imagesBasePath ending with '.py' implies that the user did not pass any arguments
@@ -42,7 +42,7 @@ print(f"Reading images from directory: {imagesBasePath}")
 imagesToParse = glob.glob(imagesBasePath+'/*.jp*g')
 
 if len(imagesToParse) == 0:
-    print('Unable to find any jpeg images in the passed directory. ')
+    print('Unable to find any jpeg images in the passed directory.')
     sys.exit()
 
 for (index, path) in enumerate(imagesToParse):
@@ -62,11 +62,11 @@ for (index, path) in enumerate(imagesToParse):
         # Add the object points and the image points to the arrays
         objectPointsArray.append(objectPoints)
         imgPointsArray.append(corners)
-        if not noGui:
+        if showGui:
             # Draw the corners on the image
             cv2.drawChessboardCorners(img, (rows, cols), corners, ret)
 
-    if not noGui:
+    if showGui:
         # Display the image
         cv2.imshow('chess board', img)
         cv2.waitKey(500)
@@ -124,7 +124,7 @@ print(
 )
 
 # Display the final result
-if not noGui:
+if showGui:
     print('Showing original vs undistorted image')
     print('Press \'0\' to close the window')
     cv2.imshow('chess board', np.hstack((img, undistortedImg)))

--- a/cameraCalib.py
+++ b/cameraCalib.py
@@ -9,6 +9,16 @@ import glob
 import sys
 import random
 
+noGui = '--no-gui' in sys.argv
+imagesBasePath = sys.argv[-1]
+
+# imagesBasePath ending with '.py' implies that the user did not pass any arguments
+if '--help' in sys.argv or imagesBasePath.endswith('.py'):
+    print('Usage: python cameraCalib.py [--no-gui] images_path')
+    print('  --no-gui: disable OpenCV GUI (may be required on Linux systems with GTK)')
+    print('  images_path: path to directory containing calibration images')
+    sys.exit()
+
 # Define the chess board rows and columns
 rows = 8
 cols = 6
@@ -24,10 +34,19 @@ objectPoints[:, :2] = np.mgrid[0:rows, 0:cols].T.reshape(-1, 2)
 objectPointsArray = []
 imgPointsArray = []
 
+# Save the grayscale version of the last image
+gray = None
+
 # Loop over the image files
-print("reading images from directory "+sys.argv[1])
-for path in glob.glob(sys.argv[1]+'/*.jp*g'):
-    print("reading image "+path)
+print(f"Reading images from directory: {imagesBasePath}")
+imagesToParse = glob.glob(imagesBasePath+'/*.jp*g')
+
+if len(imagesToParse) == 0:
+    print('Unable to find any jpeg images in the passed directory. ')
+    sys.exit()
+
+for (index,path) in enumerate(imagesToParse):
+    print(f"Reading image: {path} ({index+1}/{len(imagesToParse)})")
     # Load the image and convert it to gray scale
     img = cv2.imread(path)
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
@@ -43,17 +62,18 @@ for path in glob.glob(sys.argv[1]+'/*.jp*g'):
         # Add the object points and the image points to the arrays
         objectPointsArray.append(objectPoints)
         imgPointsArray.append(corners)
+        if not noGui:
+            # Draw the corners on the image
+            cv2.drawChessboardCorners(img, (rows, cols), corners, ret)
 
-        # Draw the corners on the image
-        cv2.drawChessboardCorners(img, (rows, cols), corners, ret)
-
-    # Display the image
-    cv2.imshow('chess board', img)
-    cv2.waitKey(500)
+    if not noGui:
+        # Display the image
+        cv2.imshow('chess board', img)
+        cv2.waitKey(500)
 
 # Calibrate the camera and save the results
 ret, mtx, dist, rvecs, tvecs = cv2.calibrateCamera(objectPointsArray, imgPointsArray, gray.shape[::-1], None, None)
-np.savez(sys.argv[1]+'/calib_data.npz', mtx=mtx, dist=dist, rvecs=rvecs, tvecs=tvecs)
+np.savez(imagesBasePath+'/calib_data.npz', mtx=mtx, dist=dist, rvecs=rvecs, tvecs=tvecs)
 print("ret", ret)
 print("mtx", mtx)
 print("dist", dist)
@@ -71,7 +91,7 @@ for i in range(len(objectPointsArray)):
 print("Total error: ", error / len(objectPointsArray))
 
 # Load one of the test images
-one_file = random.choice(glob.glob(sys.argv[1]+"/*.jp*g"))
+one_file = random.choice(imagesToParse)
 img = cv2.imread(one_file)
 h, w = img.shape[:2]
 
@@ -104,6 +124,9 @@ print(
 )
 
 # Display the final result
-cv2.imshow('chess board', np.hstack((img, undistortedImg)))
-cv2.waitKey(0)
-cv2.destroyAllWindows()
+if not noGui:
+    print('Showing original vs undistorted image')
+    print('Press \'0\' to close the window')
+    cv2.imshow('chess board', np.hstack((img, undistortedImg)))
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()

--- a/cameraCalib.py
+++ b/cameraCalib.py
@@ -45,7 +45,7 @@ if len(imagesToParse) == 0:
     print('Unable to find any jpeg images in the passed directory. ')
     sys.exit()
 
-for (index,path) in enumerate(imagesToParse):
+for (index, path) in enumerate(imagesToParse):
     print(f"Reading image: {path} ({index+1}/{len(imagesToParse)})")
     # Load the image and convert it to gray scale
     img = cv2.imread(path)


### PR DESCRIPTION
## Problem
While calibrating a camera for testing, I noticed that this script has some problems on Linux. Specifically, it shows the images during calibration using OpenCV. However, OpenCV is not compiled with GTK support by default. For Ubuntu users, fixing this is as simple as installing `libgtk2.0-dev` but for other distributions, users must recompile OpenCV which can take up to 10 minutes and is not trivial.

## Fix
Add a `--no-gui` flag that disables showing these images (but does not impact calibration)

## Additional usability changes
1. `--help` command
2. Error message for empty or invalid images directory
3. Additional print statements to help the user understand how to interact with the program

## Testing
This successfully works on my Linux laptop (I also have a compiled version of OpenCV and so I can confirm that this still works with the GUI)

## Additional Notes
This program is flaky -- On my set of images, calibration is only successful ~1/4 times. This PR does not change this.